### PR TITLE
fix: handle null characters in file paths to prevent ValueError

### DIFF
--- a/learn_async.py
+++ b/learn_async.py
@@ -110,6 +110,7 @@ def escape(s):
         .replace('"', "_")
         .replace("'", "_")
         .replace("|", "")
+        .replace("\0", "")  # Remove null characters
     )
 
 


### PR DESCRIPTION
   This PR fixes a bug where the script would fail with a ValueError when encountering null characters in file paths.
   
   Changes:
   - Added handling for null characters in the `escape` function
   - This prevents the ValueError that occurs when trying to create directories with null characters in their names
   
   The fix ensures that any null characters in file paths are removed before directory creation or file operations.