### PR TITLE
修复 process_course 中无法使用 cookie 的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 venv/
 .pass
+example_cookie.txt

--- a/learn_async.py
+++ b/learn_async.py
@@ -649,7 +649,12 @@ def clear(args):
 def process_course(c, args):
     # 处理单个课程的函数，用于多进程
     build_global(args)
-    login(args.username, args.password)
+    if args.cookie:
+        cookie.load(args.cookie, ignore_discard=True, ignore_expires=True)
+        args.login = get_page("/b/wlxt/kc/v_wlkc_xs_xktjb_coassb/queryxnxg") != err404
+        print("login successfully" if args.login else "login failed!")
+    else:
+        login(args.username, args.password)
 
     c["_type"] = {"0": "teacher", "3": "student"}[c["jslx"]]
     print("Sync " + c["xnxq"] + " " + c["kcm"])


### PR DESCRIPTION
使用 cookie 能正常登录，但无法下载文件，因为 process_course 中仅有账密登录，没有 cookie 登录的方式。本次修改加入了 cookie 登录。

此外，将 example_cookie.txt 加入 .gitignore，便于用户自行修改该文件。